### PR TITLE
Added in EARFCN retrieval for connected/primary cell

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 dependencies {
@@ -20,6 +21,8 @@ dependencies {
 //        transitive=true
 //    }
     compile "com.android.support:appcompat-v7:23.1.1"
+    compile 'eu.chainfire:libsuperuser:1.0.0.+'
+
 }
 
 android {

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -67,6 +67,9 @@
     <string name="logging_pref">Log cellular sites</string>
     <string name="logging_pref_on">Log base station information on user storage.</string>
     <string name="logging_pref_off">Logging disabled.</string>
+    <string name="earfcn_pref">Display EARFCN Data (root required)</string>
+    <string name="earfcn_pref_on">Displaying EARFCN</string>
+    <string name="earfcn_pref_off">Not displaying EARFCN</string>
     <string name="tileSource">Map tiles source</string>
     <string name="tileSourceSummary">Style of map to use.</string>
     <string name="sensorlySummary">Signal strength overlay</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -56,6 +56,13 @@
         android:title="@string/ta_distance_pref"
         />
 
+    <CheckBoxPreference
+        android:key="earfcn"
+        android:summary="@string/earfcn_pref_off"
+        android:summaryOff="@string/earfcn_pref_off"
+        android:summaryOn="@string/earfcn_pref_on"
+        android:title="@string/earfcn_pref" />
+
     <Preference
         android:key="clear_cache"
         android:persistent="false"

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -57,6 +57,7 @@
         />
 
     <CheckBoxPreference
+        android:defaultValue="false"
         android:key="earfcn"
         android:summary="@string/earfcn_pref_off"
         android:summaryOff="@string/earfcn_pref_off"

--- a/src/com/lordsutch/android/signaldetector/SignalDetector.java
+++ b/src/com/lordsutch/android/signaldetector/SignalDetector.java
@@ -342,6 +342,8 @@ public final class SignalDetector extends AppCompatActivity {
         return (pci >= 0 && pci <= 503);
     }
 
+    private Boolean validEARFCN(int earfcn) { return earfcn != Integer.MAX_VALUE; }
+
     private boolean tradunits = false;
     private boolean bsmarker = false;
     private boolean taAsDistance = false;
@@ -434,6 +436,9 @@ public final class SignalDetector extends AppCompatActivity {
 
             if (validPhysicalCellID(mSignalInfo.pci))
                 cellIds.add(String.format(Locale.getDefault(), "PCI\u00a0%03d", mSignalInfo.pci));
+
+            if (validEARFCN(mSignalInfo.earfcn))
+                cellIds.add(String.format("EARFCN\u00a0%d", mSignalInfo.earfcn));
 
             if (!cellIds.isEmpty()) {
                 servingid.setText(TextUtils.join(", ", cellIds));

--- a/src/com/lordsutch/android/signaldetector/SignalDetectorService.java
+++ b/src/com/lordsutch/android/signaldetector/SignalDetectorService.java
@@ -61,7 +61,6 @@ class otherLteCell implements Parcelable {
     int mcc = Integer.MAX_VALUE;
     int mnc = Integer.MAX_VALUE;
     int earfcn = Integer.MAX_VALUE;
-    int rsrq = Integer.MAX_VALUE;
     int lteBand = 0;
 
     int lteSigStrength = Integer.MAX_VALUE;
@@ -80,7 +79,6 @@ class otherLteCell implements Parcelable {
         dest.writeInt(this.mcc);
         dest.writeInt(this.mnc);
         dest.writeInt(this.earfcn);
-        dest.writeInt(this.rsrq);
         dest.writeInt(this.lteBand);
         dest.writeInt(this.lteSigStrength);
         dest.writeInt(this.timingAdvance);
@@ -96,7 +94,6 @@ class otherLteCell implements Parcelable {
         this.mcc = in.readInt();
         this.mnc = in.readInt();
         this.earfcn = in.readInt();
-        this.rsrq = in.readInt();
         this.lteBand = in.readInt();
         this.lteSigStrength = in.readInt();
         this.timingAdvance = in.readInt();
@@ -132,7 +129,6 @@ class signalInfo implements Parcelable {
     int mcc = Integer.MAX_VALUE;
     int mnc = Integer.MAX_VALUE;
     int earfcn = Integer.MAX_VALUE;
-    int rsrq = Integer.MAX_VALUE;
     int lteSigStrength = Integer.MAX_VALUE;
     int timingAdvance = Integer.MAX_VALUE;
 
@@ -183,7 +179,6 @@ class signalInfo implements Parcelable {
         dest.writeInt(this.mcc);
         dest.writeInt(this.mnc);
         dest.writeInt(this.earfcn);
-        dest.writeInt(this.rsrq);
         dest.writeInt(this.lteSigStrength);
         dest.writeInt(this.lteBand);
         dest.writeInt(this.bsid);
@@ -224,7 +219,6 @@ class signalInfo implements Parcelable {
         this.mcc = in.readInt();
         this.mnc = in.readInt();
         this.earfcn = in.readInt();
-        this.rsrq = in.readInt();
         this.lteSigStrength = in.readInt();
         this.lteBand = in.readInt();
         this.bsid = in.readInt();
@@ -559,7 +553,7 @@ public class SignalDetectorService extends Service {
         return (tac > 0x0000 && tac < 0xFFFF); // 0, FFFF are reserved values
     }
 
-    Boolean validEARFCN(int earfcn) {
+    boolean validEARFCN(int earfcn) {
         return ( earfcn != Integer.MAX_VALUE);
     } // Integer.MAX_VALUE signifies no change or empty / default EARFCN
 
@@ -897,14 +891,12 @@ public class SignalDetectorService extends Service {
                         (validTAC(signal.tac) ? String.format(Locale.US, "%04X", signal.tac) : "") + "," +
                         String.format(Locale.US, "%.0f", signal.accuracy) + "," +
                         (validCellID(signal.gci) ? String.format(Locale.US, "%06X", signal.gci /256) : "") + "," +
-//   OK to add EARFCN here? And below?
-//                        (validEARFCN(signal.earfcn) ? String.format(Locale.US, "%d", signal.earfcn) : "") + "," +
                         (signal.lteBand > 0 ? String.valueOf(signal.lteBand) : "") + "," +
-                        (validTimingAdvance(signal.timingAdvance) ? String.valueOf(signal.timingAdvance) : "");
+                        (validTimingAdvance(signal.timingAdvance) ? String.valueOf(signal.timingAdvance) : "") + "," +
+                        (validEARFCN(signal.earfcn) ? String.format(Locale.US, "%d", signal.earfcn) : "");
                 if (lteLine == null || !newLteLine.equals(lteLine)) {
                     Log.d(TAG, "Logging LTE cell.");
-                    appendLog("ltecells.csv", newLteLine, "latitude,longitude,cellid,physcellid,dBm,altitude,tac,accuracy,baseGci,band,timingAdvance");
-//                    appendLog("ltecells.csv", newLteLine, "latitude,longitude,cellid,physcellid,dBm,altitude,tac,accuracy,baseGci,earfcn,band,timingAdvance");
+                    appendLog("ltecells.csv", newLteLine, "latitude,longitude,cellid,physcellid,dBm,altitude,tac,accuracy,baseGci,band,timingAdvance,earfcn");
                     lteLine = newLteLine;
                 }
             }
@@ -935,13 +927,12 @@ public class SignalDetectorService extends Service {
                                 (validLTESignalStrength(rsrp) ? String.valueOf(rsrp) : "") + "," +
                                 (item.isRegistered() ? "1" : "0") + "," +
                                 (validCellID(eci) ? String.format(Locale.US, "%06X", eci /256) : "") + "," +
-//                                (validEARFCN(signal.earfcn) ? String.format(Locale.US, "%d", signal.earfcn) : "") + "," +
                                 (lteBand > 0 ? String.valueOf(lteBand) : "") + "," +
-                                (validTimingAdvance(timingAdvance) ? String.valueOf(timingAdvance) : "");
+                                (validTimingAdvance(timingAdvance) ? String.valueOf(timingAdvance) : "") + "," +
+                                (validEARFCN(signal.earfcn) ? String.format(Locale.US, "%d", signal.earfcn) : "");
 
                         appendLog("cellinfolte.csv", cellLine,
-                                "latitude,longitude,accuracy,altitude,mcc,mnc,tac,gci,pci,rsrp,registered,baseGci,band,timingAdvance");
-//                                "latitude,longitude,accuracy,altitude,mcc,mnc,tac,gci,pci,rsrp,registered,baseGci,earfcn,band,timingAdvance");
+                                "latitude,longitude,accuracy,altitude,mcc,mnc,tac,gci,pci,rsrp,registered,baseGci,band,timingAdvance,earfcn");
 
                     }
                 }


### PR DESCRIPTION
This allows enabling/disabling retrieval of the earfcn. It fails gracefully (ie disables the feature) if anything goes wrong (such as root not being present or being denied, the modem serial device not being present, etc).

EARFCN is not currently logged. I added the modifications for this, but left them commented out. I didn't know if it would disrupt existing entries or cause other issues. Feel free to uncomment them if it won't be a problem.

EARFCN can is also fetched for neighbor cells and can also be used to accurately determine the band. Currently I just drop them because the command runs asynchronously, thus I can't guarantee that the list of neighbor cells returned directly from the modem will match the ones returned from the Android API, and in the same order. The latter matters because sometimes the PCI is the same on 2 different bands and may appear twice in the list, and there is no way to distinguish which is which when matching them to the officially reported neighbor cells, unless the signal level matches. 
